### PR TITLE
Free Ogg memory after playing an audio file.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -27,6 +27,7 @@ audioTransmission_stop(AudioTransmission *at, lua_State *lua, struct ev_loop *lo
     if (at == NULL || lua == NULL || loop == NULL) {
         return;
     }
+    ov_clear(&at->ogg);
     fclose(at->file);
     ev_timer_stop(loop, &at->ev);
 


### PR DESCRIPTION
ov_open_callbacks is called with OV_CALLBACKS_STREAMONLY_NOCLOSE, so ov_clear should be called to free the decoder's buffers in audioTransmission_stop.
See: https://xiph.org/vorbis/doc/vorbisfile/ov_clear.html
